### PR TITLE
turn/autorun -> minitest/autorun

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -19,4 +19,4 @@ class ActiveSupport::TestCase
 end
 
 # Formatting test output a litte nicer
-Turn.config.format = :outline
+# Turn.config.format = :outline

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,7 +3,7 @@ SimpleCov.start 'rails'
 ENV["RAILS_ENV"] ||= "test"
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
-require 'turn/autorun'
+require 'minitest/autorun'
 require 'contexts'
 
 class ActiveSupport::TestCase


### PR DESCRIPTION
'turn/autorun' wasn't existing/working for some people, including me.
Neither was Turn.config